### PR TITLE
Make getty services go down when tty is absent

### DIFF
--- a/etc/sv/getty-ttyv1/run
+++ b/etc/sv/getty-ttyv1/run
@@ -3,5 +3,6 @@ tty=${PWD##*-}
 [ -r conf ] && . ./conf
 : "${TYPE:=Pc}"
 : "${TERM:=xterm}"
+[ ! -c /dev/${tty} ] && sv d getty-${tty}
 export TERM
 exec /usr/libexec/getty ${TYPE} "${tty}"


### PR DESCRIPTION
This is useful for systems that are sometimes headless (no ttyv*) and sometimes not (many ttyv*).